### PR TITLE
Make the primary color customizable. Fix #7

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -124,6 +124,8 @@
         <div class="mb-2">
             <span class="badge mb-1">Default</span>
 
+            <span class="badge badge-dark mb-1">Dark</span>
+
             <span class="badge badge-light mb-1">Light</span>
 
             <span class="badge badge-blue mb-1">Blue</span>

--- a/docs/output.css
+++ b/docs/output.css
@@ -662,7 +662,7 @@ p {
 }
 
 .btn:hover {
-  background-color: #2d3748;
+  background-color: #333333;
 }
 
 .btn-outline {
@@ -673,17 +673,8 @@ p {
 }
 
 .btn-outline:hover {
-  background-color: #2d3748;
+  background-color: #000;
   color: #fff;
-}
-
-.card {
-  padding: 1.5rem;
-  background-color: #fff;
-  border-radius: 0.25rem;
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-  border-width: 1px;
-  border-color: #edf2f7;
 }
 
 .badge {
@@ -695,6 +686,11 @@ p {
   border-radius: 0.25rem;
   font-size: 0.875rem;
   font-weight: 700;
+  background-color: #000;
+  color: #fff;
+}
+
+.badge-dark {
   background-color: #000;
   color: #fff;
 }
@@ -722,6 +718,15 @@ p {
 .badge-red {
   background-color: #f56565;
   color: #fff;
+}
+
+.card {
+  padding: 1.5rem;
+  background-color: #fff;
+  border-radius: 0.25rem;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  border-width: 1px;
+  border-color: #edf2f7;
 }
 
 .alert {
@@ -795,8 +800,8 @@ p {
 
 .form-input:focus {
   outline: none;
-  box-shadow: 0 0 0 3px rgba(66, 153, 225, 0.5);
-  border-color: #63b3ed;
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.2);
+  border-color: rgba(0, 0, 0, 0.4);
 }
 
 .form-textarea {
@@ -832,8 +837,8 @@ p {
 
 .form-textarea:focus {
   outline: none;
-  box-shadow: 0 0 0 3px rgba(66, 153, 225, 0.5);
-  border-color: #63b3ed;
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.2);
+  border-color: rgba(0, 0, 0, 0.4);
 }
 
 .form-multiselect {
@@ -854,8 +859,8 @@ p {
 
 .form-multiselect:focus {
   outline: none;
-  box-shadow: 0 0 0 3px rgba(66, 153, 225, 0.5);
-  border-color: #63b3ed;
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.2);
+  border-color: rgba(0, 0, 0, 0.4);
 }
 
 .form-select {
@@ -899,8 +904,8 @@ p {
 
 .form-select:focus {
   outline: none;
-  box-shadow: 0 0 0 3px rgba(66, 153, 225, 0.5);
-  border-color: #63b3ed;
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.2);
+  border-color: rgba(0, 0, 0, 0.4);
 }
 
 .form-checkbox:checked {
@@ -938,7 +943,7 @@ p {
   flex-shrink: 0;
   height: 1em;
   width: 1em;
-  color: #4299e1;
+  color: #000;
   background-color: #fff;
   border-color: #e2e8f0;
   border-width: 1px;
@@ -947,8 +952,8 @@ p {
 
 .form-checkbox:focus {
   outline: none;
-  box-shadow: 0 0 0 3px rgba(66, 153, 225, 0.5);
-  border-color: #63b3ed;
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.2);
+  border-color: rgba(0, 0, 0, 0.4);
 }
 
 .form-radio:checked {
@@ -987,7 +992,7 @@ p {
   border-radius: 100%;
   height: 1em;
   width: 1em;
-  color: #4299e1;
+  color: #000;
   background-color: #fff;
   border-color: #e2e8f0;
   border-width: 1px;
@@ -995,8 +1000,8 @@ p {
 
 .form-radio:focus {
   outline: none;
-  box-shadow: 0 0 0 3px rgba(66, 153, 225, 0.5);
-  border-color: #63b3ed;
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.2);
+  border-color: rgba(0, 0, 0, 0.4);
 }
 
 .space-y-0 > :not(template) ~ :not(template) {

--- a/docs/tailwind.config.js
+++ b/docs/tailwind.config.js
@@ -5,7 +5,11 @@ module.exports = {
   },
   purge: [],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        // primary: '#ff6394'
+      }
+    },
   },
   variants: {},
   plugins: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sailui",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "Basic UI components for Tailwind CSS.",
   "main": "src/sailui.js",
   "repository": "https://github.com/sailui/ui.git",
@@ -17,13 +17,13 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@tailwindcss/custom-forms": "^0.2.1"
+    "@tailwindcss/custom-forms": "^0.2.1",
+    "tinycolor2": "^1.4.2"
   },
   "peerDependencies": {
     "tailwindcss": "^1.9.5"
   },
   "scripts": {
-    "build": "npx tailwindcss build demo/styles.css -o demo/output.css",
-    "watch": "npm run build -- --watch"
+    "build": "npx tailwindcss build docs/styles.css -o docs/output.css -c docs/tailwind.config.js"
   }
 }

--- a/src/components/badge.js
+++ b/src/components/badge.js
@@ -1,39 +1,50 @@
-module.exports = {
-  '.badge': {
-    display: 'inline-block',
-    paddingTop: '0',
-    paddingBottom: '0',
-    paddingLeft: '0.5rem',
-    paddingRight: '0.5rem',
-    borderRadius: '0.25rem',
-    fontSize: '0.875rem',
-    fontWeight: 700,
-    backgroundColor: '#000',
-    color: '#fff'
-  },
+const tc = require('tinycolor2')
 
-  '.badge-light': {
-    backgroundColor: '#edf2f7',
-    color: '#000'
-  },
+module.exports = ({theme}) => {
+  let primaryColor = theme('colors.primary')
 
-  '.badge-blue': {
-    backgroundColor: '#4299e1',
-    color: '#fff'
-  },
+  return {
+    '.badge': {
+      display: 'inline-block',
+      paddingTop: '0',
+      paddingBottom: '0',
+      paddingLeft: '0.5rem',
+      paddingRight: '0.5rem',
+      borderRadius: '0.25rem',
+      fontSize: '0.875rem',
+      fontWeight: 700,
+      backgroundColor: primaryColor,
+      color: tc(primaryColor).getBrightness() < 200 ? '#fff' : '#000'
+    },
 
-  '.badge-green': {
-    backgroundColor: '#48bb78',
-    color: '#fff'
-  },
+    '.badge-dark': {
+      backgroundColor: '#000',
+      color: '#fff'
+    },
 
-  '.badge-yellow': {
-    backgroundColor: '#f6e05e',
-    color: '#000'
-  },
+    '.badge-light': {
+      backgroundColor: '#edf2f7',
+      color: '#000'
+    },
 
-  '.badge-red': {
-    backgroundColor: '#f56565',
-    color: '#fff'
+    '.badge-blue': {
+      backgroundColor: '#4299e1',
+      color: '#fff'
+    },
+
+    '.badge-green': {
+      backgroundColor: '#48bb78',
+      color: '#fff'
+    },
+
+    '.badge-yellow': {
+      backgroundColor: '#f6e05e',
+      color: '#000'
+    },
+
+    '.badge-red': {
+      backgroundColor: '#f56565',
+      color: '#fff'
+    }
   }
 }

--- a/src/components/btn.js
+++ b/src/components/btn.js
@@ -1,31 +1,47 @@
-module.exports = {
-  '.btn': {
-    display: 'inline-block',
-    paddingTop: '0.5rem',
-    paddingBottom: '0.5rem',
-    paddingLeft: '1.5rem',
-    paddingRight: '1.5rem',
-    transitionProperty: 'background-color, border-color, color, fill, stroke',
-    transitionDuration: '200ms',
-    cursor: 'pointer',
-    borderRadius: '0.25rem',
-    backgroundColor: '#000',
-    color: '#fff',
+const tc = require('tinycolor2')
 
-    '&:hover': {
-      backgroundColor: '#2d3748'
+module.exports = ({theme}) => {
+  let primaryColor = theme('colors.primary')
+  let hoverColor = tc(primaryColor).clone()
+
+  if(hoverColor.getBrightness() < 10){
+    hoverColor.lighten(20);
+  }
+  else{
+    hoverColor.darken(10)
+  }
+
+  hoverColor = hoverColor.toString()
+
+  return {
+    '.btn': {
+      display: 'inline-block',
+      paddingTop: '0.5rem',
+      paddingBottom: '0.5rem',
+      paddingLeft: '1.5rem',
+      paddingRight: '1.5rem',
+      transitionProperty: 'background-color, border-color, color, fill, stroke',
+      transitionDuration: '200ms',
+      cursor: 'pointer',
+      borderRadius: '0.25rem',
+      backgroundColor: primaryColor,
+      color: '#fff',
+
+      '&:hover': {
+        backgroundColor: hoverColor
+      },
     },
-  },
 
-  '.btn-outline': {
-    borderWidth: '1px',
-    borderColor: '#000',
-    color: '#000',
-    backgroundColor: 'transparent',
+    '.btn-outline': {
+      borderWidth: '1px',
+      borderColor: primaryColor,
+      color: primaryColor,
+      backgroundColor: 'transparent',
 
-    '&:hover': {
-      backgroundColor: '#2d3748',
-      color: '#fff'
+      '&:hover': {
+        backgroundColor: primaryColor,
+        color: '#fff'
+      }
     }
   }
 }

--- a/src/sailui.js
+++ b/src/sailui.js
@@ -1,13 +1,21 @@
 const plugin = require('tailwindcss/plugin')
 
-module.exports = plugin(function({addComponents, addUtilities, addBase, theme, postcss}) {
+module.exports = plugin(function ({addComponents, addUtilities, addBase, theme, postcss}) {
+  let sailTheme = require('./themes/sailTheme')({theme})
+  let formTheme = require('./themes/formTheme')({theme: sailTheme})
+
   addBase(require('./typography'))
 
-  addComponents(require('./components/btn'))
+  addComponents(require('./components/btn')({theme: sailTheme}))
+  addComponents(require('./components/badge')({theme: sailTheme}))
   addComponents(require('./components/card'))
-  addComponents(require('./components/badge'))
   addComponents(require('./components/alert'))
   addComponents(require('./components/container'))
 
-  require('@tailwindcss/custom-forms')({addUtilities, addComponents, theme, postcss})
+  require('@tailwindcss/custom-forms')({
+    addUtilities,
+    addComponents,
+    postcss,
+    theme: formTheme
+  })
 })

--- a/src/themes/formTheme.js
+++ b/src/themes/formTheme.js
@@ -1,0 +1,27 @@
+const tc = require('tinycolor2')
+
+module.exports = ({theme}) => {
+  return (key) => {
+    let primaryColor = theme('colors.primary')
+    let value = theme(key)
+
+    if (key !== 'customForms') {
+      return value
+    }
+
+    return {
+      default: {
+        'input, textarea, multiselect, select, checkbox, radio': {
+          '&:focus': {
+            boxShadow: `0 0 0 3px ${tc(primaryColor).setAlpha(0.2).toString()}`,
+            borderColor: tc(primaryColor).setAlpha(0.4).toString(),
+          },
+        },
+
+        'checkbox, radio': {
+          color: primaryColor,
+        },
+      },
+    }
+  }
+}

--- a/src/themes/sailTheme.js
+++ b/src/themes/sailTheme.js
@@ -1,0 +1,11 @@
+module.exports = ({theme}) => {
+  return (key) => {
+    let value = theme(key)
+
+    if(key === 'colors.primary' && typeof value === 'undefined'){
+      return '#000'
+    }
+
+    return value;
+  }
+}


### PR DESCRIPTION
Prior to this, Sail UI used *black* as the default color for styling all its components. For example, the default button was colored black.

This PR allows user to define a `theme.colors.primary` key on their `tailwind.config.js` file to change the primary color across all available Sail UI components.

Usage example:
```js
module.exports = {
  // ...
  theme: {
    extend: {
      colors: {
         primary: '#ff6394'
      }
    }
  }
}
```

Before: 
![image](https://user-images.githubusercontent.com/10030505/98333819-88ca0680-203c-11eb-9429-782e752bacfc.png)

After:
![image](https://user-images.githubusercontent.com/10030505/98333739-620bd000-203c-11eb-93f5-073a91a73215.png)
