### PR TITLE
Fix: Update usage of @tailwdincss/forms 

### DIFF
--- a/src/sailui.js
+++ b/src/sailui.js
@@ -18,6 +18,6 @@ module.exports = plugin(function ({addComponents, addUtilities, addBase, theme, 
   addComponents(require('./components/form/radio')({theme: sailTheme}))
   addComponents(require('./components/form/textarea')({theme: sailTheme}))
 
-  let forms = require('@tailwindcss/forms')
+  let forms = require('@tailwindcss/forms')();
   forms.handler({addBase, theme})
 })


### PR DESCRIPTION
In version 3.0.0 of tailwindcss/forms was added a plugin option for `strategy`:

https://github.com/tailwindlabs/tailwindcss-forms/blob/master/CHANGELOG.md#030---2021-03-25

and I (think I) fixed the problem I described in  https://github.com/sailui/ui/issues/17